### PR TITLE
README: add Ambire Wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@
 - https://github.com/base/eip-7702-proxy
 - https://github.com/openfort-xyz/openfort-contracts/blob/feat/eip-7702/contracts/core/upgradeable/UpgradeableOpenfortProxy7702.sol
 
+### Wallets
+- [Ambire Wallet](https://www.ambire.com/); a browser extension that supports (smarter) EOAs and Smart Accounts in one place
+
 ### POCs & Demos
 - Ithaca Demos:
   - [EXP-0001: Account Delegation with EIP-7702](https://www.ithaca.xyz/updates/exp-0001)


### PR DESCRIPTION
adding Ambire as it currently supports EIP-7702 on Odyssey (https://x.com/AmbireWallet/status/1892941598381723880) if you build from GitHub, and it will support it on mainnet as soon as it's launched

Demo here: https://x.com/AmbireWallet/status/1892941598381723880