### PR TITLE
Add EIP-7702 Delegation Checker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - [Foundry Delegation Signatures](https://book.getfoundry.sh/cheatcodes/sign-delegation)
 - [Micro Eth Signer](https://github.com/paulmillr/micro-eth-signer)
 - [Wallet Checker](https://7702checker.azfuller.com/)
+- [EIP-7702 Delegation Checker](https://eip7702.app/)
 
 ### Smart account frameworks
 - Metamask: Delegation Framework - [Delegation Framework 7702 Code](https://github.com/MetaMask/delegation-framework/tree/main/src/EIP7702) / [Delegation Framework 7702 Doc](https://github.com/MetaMask/delegation-framework/blob/main/documents/EIP7702DeleGator.md)


### PR DESCRIPTION
Added EIP-7702 Delegation Checker link to README.

It's dependency free and live at [eip7702.app](https://eip7702.app/). The source code can be inspected there, it's just straightforward HTML/JS/CSS.

We've also opened an associated issue with MetaMask and added a note to an existing Rabby issue, for EIP-7702 revocation support:
- https://github.com/MetaMask/metamask-extension/issues/35520
- https://github.com/RabbyHub/Rabby/issues/3102#issuecomment-3290072789

Real world use examples:
- https://x.com/JeffInTokyo/status/1967259513519796358
- https://x.com/0xRiim/status/1967313378956784060