### PR TITLE
Add Uniswap Wallet and Rainbow Wallet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@
 - [Trust Wallet](https://beincrypto.com/trust-wallet-ethereum-eip7702-support/)
 - [OKX Wallet](https://web3.okx.com/help/okx-wallet-to-support-eip-7702)
 - [Openfort](https://www.openfort.io/docs/products/embedded-wallet/7702#quickstart---7702-accounts)
+- [Rainbow Wallet](https://github.com/rainbow-me/calibur) - Calibur EIP-7702 delegation contract
+- [Uniswap Wallet](https://github.com/Uniswap/calibur) - Calibur EIP-7702 delegation contract
 
 ### Blockchain Support
 - [7702 Beat](https://swiss-knife.xyz/7702beat) - by Swiss-knife.xyz

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - [Trust Wallet](https://beincrypto.com/trust-wallet-ethereum-eip7702-support/)
 - [OKX Wallet](https://web3.okx.com/help/okx-wallet-to-support-eip-7702)
 - [Openfort](https://www.openfort.io/docs/products/embedded-wallet/7702#quickstart---7702-accounts)
-- [Rainbow Wallet](https://github.com/rainbow-me/calibur) - Calibur EIP-7702 delegation contract
+- [Rainbow Wallet](https://github.com/uniswap/calibur) - Calibur EIP-7702 delegation contract
 - [Uniswap Wallet](https://github.com/Uniswap/calibur) - Calibur EIP-7702 delegation contract
 
 ### Blockchain Support

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - https://github.com/Vectorized/solady/blob/main/src/accounts/EIP7702Proxy.sol
 - https://github.com/base/eip-7702-proxy
 - https://github.com/openfort-xyz/openfort-7702-account
+- https://github.com/uniswap/calibur
 
 ### POCs & Demos
 - Ithaca Demos:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@
 - [Trust Wallet](https://beincrypto.com/trust-wallet-ethereum-eip7702-support/)
 - [OKX Wallet](https://web3.okx.com/help/okx-wallet-to-support-eip-7702)
 - [Openfort](https://www.openfort.io/docs/products/embedded-wallet/7702#quickstart---7702-accounts)
-- [Rainbow Wallet](https://github.com/uniswap/calibur)
-- [Uniswap Wallet](https://github.com/Uniswap/calibur)
+- [Rainbow Wallet](https://x.com/rainbowdotme/status/2026753700216127820)
+- [Uniswap Wallet](https://support.uniswap.org/hc/en-us/articles/36391987158797-Smart-Wallets-and-Delegation)
 
 ### Blockchain Support
 - [7702 Beat](https://swiss-knife.xyz/7702beat) - by Swiss-knife.xyz

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@
 - [Trust Wallet](https://beincrypto.com/trust-wallet-ethereum-eip7702-support/)
 - [OKX Wallet](https://web3.okx.com/help/okx-wallet-to-support-eip-7702)
 - [Openfort](https://www.openfort.io/docs/products/embedded-wallet/7702#quickstart---7702-accounts)
-- [Rainbow Wallet](https://github.com/uniswap/calibur) - Calibur EIP-7702 delegation contract
-- [Uniswap Wallet](https://github.com/Uniswap/calibur) - Calibur EIP-7702 delegation contract
+- [Rainbow Wallet](https://github.com/uniswap/calibur)
+- [Uniswap Wallet](https://github.com/Uniswap/calibur)
 
 ### Blockchain Support
 - [7702 Beat](https://swiss-knife.xyz/7702beat) - by Swiss-knife.xyz


### PR DESCRIPTION
Adds Uniswap Wallet and Rainbow Wallet to the list, both of which have deployed EIP-7702 Calibur delegation contracts.

- Calibur: https://github.com/uniswap/calibur (`0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00`)
- RainbowCalibur: https://github.com/uniswap/calibur (`0x612373D7003d694220f7800EeaF8E3924c0951D3`)

## Announcements:
- Rainbow Wallet: https://x.com/rainbowdotme/status/2026753700216127820
- Uniswap Wallet: https://support.uniswap.org/hc/en-us/articles/36391987158797-Smart-Wallets-and-Delegation